### PR TITLE
DAT-36: ability to manage users in IS Admin role.

### DIFF
--- a/datavault-broker/src/main/java/org/datavaultplatform/broker/controllers/RolesAndPermissionsController.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/broker/controllers/RolesAndPermissionsController.java
@@ -4,7 +4,9 @@ import org.datavaultplatform.broker.services.RolesAndPermissionsService;
 import org.datavaultplatform.common.model.PermissionModel;
 import org.datavaultplatform.common.model.RoleAssignment;
 import org.datavaultplatform.common.model.RoleModel;
-import org.jsondoc.core.annotation.*;
+import org.jsondoc.core.annotation.Api;
+import org.jsondoc.core.annotation.ApiMethod;
+import org.jsondoc.core.annotation.ApiPathParam;
 import org.jsondoc.core.pojo.ApiVerb;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -204,6 +206,20 @@ public class RolesAndPermissionsController {
             @ApiPathParam(name = "User ID", description = "The ID of the user to get role assignments for") @PathVariable("userId") String userId) {
         List<RoleAssignment> schoolRoleAssignments = rolesAndPermissionsService.getRoleAssignmentsForUser(userId);
         return schoolRoleAssignments.toArray(new RoleAssignment[0]);
+    }
+
+    @ApiMethod(
+            path = "/permissions/roleAssignments/role/{roleId}",
+            verb = ApiVerb.GET,
+            description = "Gets all role assignments for a given role",
+            produces = {MediaType.APPLICATION_JSON_VALUE},
+            responsestatuscode = "200 - OK"
+    )
+    @GetMapping("/roleAssignments/role/{roleId}")
+    public RoleAssignment[] getRoleAssignmentsForRole(
+            @ApiPathParam(name = "Role ID", description = "The ID of the role to get role assignments for") @PathVariable("roleId") Long roleId) {
+        List<RoleAssignment> roleAssignments = rolesAndPermissionsService.getRoleAssignmentsForRole(roleId);
+        return roleAssignments.toArray(new RoleAssignment[0]);
     }
 
     @ApiMethod(

--- a/datavault-broker/src/main/java/org/datavaultplatform/broker/services/RolesAndPermissionsService.java
+++ b/datavault-broker/src/main/java/org/datavaultplatform/broker/services/RolesAndPermissionsService.java
@@ -148,6 +148,10 @@ public class RolesAndPermissionsService implements ApplicationListener<ContextRe
         return roleAssignmentDao.findByUserId(userId);
     }
 
+    public List<RoleAssignment> getRoleAssignmentsForRole(Long roleId) {
+        return roleAssignmentDao.findByRoleId(roleId);
+    }
+
     public RoleModel updateRole(RoleModel role) {
         if (!roleExists(role.getId())) {
             throw new IllegalStateException("Cannot update a role that does not exist");

--- a/datavault-common/src/main/java/org/datavaultplatform/common/model/RoleModel.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/model/RoleModel.java
@@ -5,6 +5,7 @@ import com.google.common.collect.Sets;
 
 import javax.persistence.*;
 import java.util.Collection;
+import java.util.Objects;
 
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -94,5 +95,18 @@ public class RoleModel {
         // TODO we need to provide the count of assigned users with the role but won't have a working impl until the
         // stories to assign users to roles are developed
         return 0;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RoleModel roleModel = (RoleModel) o;
+        return Objects.equals(id, roleModel.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/datavault-common/src/main/java/org/datavaultplatform/common/model/dao/RoleAssignmentDAO.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/model/dao/RoleAssignmentDAO.java
@@ -20,6 +20,8 @@ public interface RoleAssignmentDAO {
 
     List<RoleAssignment> findByUserId(String userId);
 
+    List<RoleAssignment> findByRoleId(Long roleId);
+
     void update(RoleAssignment roleAssignment);
 
     void delete(Long id);

--- a/datavault-common/src/main/java/org/datavaultplatform/common/model/dao/RoleAssignmentDaoImpl.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/model/dao/RoleAssignmentDaoImpl.java
@@ -13,7 +13,8 @@ public class RoleAssignmentDaoImpl implements RoleAssignmentDAO {
 
     private SessionFactory sessionFactory;
 
-    public RoleAssignmentDaoImpl() {}
+    public RoleAssignmentDaoImpl() {
+    }
 
     public void setSessionFactory(SessionFactory sessionFactory) {
         this.sessionFactory = sessionFactory;
@@ -21,56 +22,84 @@ public class RoleAssignmentDaoImpl implements RoleAssignmentDAO {
 
     @Override
     public boolean roleAssignmentExists(RoleAssignment roleAssignment) {
-        Session session = this.sessionFactory.openSession();
-        Criteria criteria = session.createCriteria(RoleAssignment.class);
-        criteria.add(Restrictions.eq("role", roleAssignment.getRole()));
-        criteria.add(Restrictions.eq("user", roleAssignment.getUser()));
-        if (roleAssignment.getSchool() != null) {
-            criteria.add(Restrictions.eq("school", roleAssignment.getSchool()));
+        Session session = null;
+        try {
+            session = this.sessionFactory.openSession();
+
+            Criteria criteria = session.createCriteria(RoleAssignment.class);
+            criteria.add(Restrictions.eq("role", roleAssignment.getRole()));
+            criteria.add(Restrictions.eq("user", roleAssignment.getUser()));
+            if (roleAssignment.getSchool() != null) {
+                criteria.add(Restrictions.eq("school", roleAssignment.getSchool()));
+            }
+            if (roleAssignment.getVault() != null) {
+                criteria.add(Restrictions.eq("vault", roleAssignment.getVault()));
+            }
+            return criteria.uniqueResult() != null;
+        } finally {
+            if (session != null) session.close();
         }
-        if (roleAssignment.getVault() != null) {
-            criteria.add(Restrictions.eq("vault", roleAssignment.getVault()));
-        }
-        boolean exists = criteria.uniqueResult() != null;
-        session.close();
-        return exists;
+
     }
 
     @Override
     public void store(RoleAssignment roleAssignment) {
-        Session session = this.sessionFactory.openSession();
-        Transaction tx = session.beginTransaction();
-        session.persist(roleAssignment);
-        tx.commit();
-        session.close();
+        Session session = null;
+        try {
+            session = this.sessionFactory.openSession();
+
+            Transaction tx = session.beginTransaction();
+            session.persist(roleAssignment);
+            tx.commit();
+        } finally {
+            if (session != null) session.close();
+        }
     }
 
     @Override
     public RoleAssignment find(Long id) {
-        Session session = this.sessionFactory.openSession();
-        Criteria criteria = session.createCriteria(RoleAssignment.class);
-        criteria.add(Restrictions.eq("id", id));
-        RoleAssignment roleAssignment = (RoleAssignment) criteria.uniqueResult();
-        session.close();
-        return roleAssignment;
+        Session session = null;
+        try {
+            session = this.sessionFactory.openSession();
+
+            Criteria criteria = session.createCriteria(RoleAssignment.class);
+            criteria.add(Restrictions.eq("id", id));
+            RoleAssignment roleAssignment = (RoleAssignment) criteria.uniqueResult();
+            return roleAssignment;
+        } finally {
+            if (session != null) session.close();
+        }
+
     }
 
     @Override
     public List<RoleAssignment> findAll() {
-        Session session = this.sessionFactory.openSession();
-        Criteria criteria = session.createCriteria(RoleAssignment.class);
-        List<RoleAssignment> roleAssignments = criteria.list();
-        session.close();
-        return roleAssignments;
+        Session session = null;
+        try {
+            session = this.sessionFactory.openSession();
+
+            Criteria criteria = session.createCriteria(RoleAssignment.class);
+            List<RoleAssignment> roleAssignments = criteria.list();
+            return roleAssignments;
+        } finally {
+            if (session != null) session.close();
+        }
+
     }
 
     @Override
     public List<RoleAssignment> findBySchoolId(String schoolId) {
-        Session session = sessionFactory.openSession();
-        Group school = findObjectById(session, Group.class, "id", schoolId);
-        List<RoleAssignment> schoolAssignments = findBy(session, "school", school);
-        session.close();
-        return schoolAssignments;
+        Session session = null;
+        try {
+            session = sessionFactory.openSession();
+
+            Group school = findObjectById(session, Group.class, "id", schoolId);
+            List<RoleAssignment> schoolAssignments = findBy(session, "school", school);
+            return schoolAssignments;
+        } finally {
+            if (session != null) session.close();
+        }
+
     }
 
     private <T> T findObjectById(Session session, Class<T> type, String idName, Object idValue) {
@@ -87,47 +116,75 @@ public class RoleAssignmentDaoImpl implements RoleAssignmentDAO {
 
     @Override
     public List<RoleAssignment> findByVaultId(String vaultId) {
-        Session session = sessionFactory.openSession();
-        Vault vault = findObjectById(session, Vault.class, "id", vaultId);
-        List<RoleAssignment> schoolAssignments = findBy(session, "vault", vault);
-        session.close();
-        return schoolAssignments;
+        Session session = null;
+        try {
+            session = sessionFactory.openSession();
+
+            Vault vault = findObjectById(session, Vault.class, "id", vaultId);
+            List<RoleAssignment> schoolAssignments = findBy(session, "vault", vault);
+            return schoolAssignments;
+        } finally {
+            if (session != null) session.close();
+        }
+
     }
 
     @Override
     public List<RoleAssignment> findByUserId(String userId) {
-        Session session = sessionFactory.openSession();
-        User user = findObjectById(session, User.class, "id", userId);
-        List<RoleAssignment> schoolAssignments = findBy(session, "user", user);
-        session.close();
-        return schoolAssignments;
+        Session session = null;
+        try {
+            session = sessionFactory.openSession();
+
+            User user = findObjectById(session, User.class, "id", userId);
+            List<RoleAssignment> schoolAssignments = findBy(session, "user", user);
+            return schoolAssignments;
+        } finally {
+            if (session != null) session.close();
+        }
+
     }
 
     @Override
     public List<RoleAssignment> findByRoleId(Long roleId) {
-        Session session = sessionFactory.openSession();
-        RoleModel role = findObjectById(session, RoleModel.class, "id", roleId);
-        List<RoleAssignment> assignments = findBy(session, "role", role);
-        session.close();
-        return assignments;
+        Session session = null;
+        try {
+            session = sessionFactory.openSession();
+
+            RoleModel role = findObjectById(session, RoleModel.class, "id", roleId);
+            List<RoleAssignment> assignments = findBy(session, "role", role);
+            return assignments;
+        } finally {
+            if (session != null) session.close();
+        }
+
     }
 
     @Override
     public void update(RoleAssignment roleAssignment) {
-        Session session = this.sessionFactory.openSession();
-        Transaction tx = session.beginTransaction();
-        session.update(roleAssignment);
-        tx.commit();
-        session.close();
+        Session session = null;
+        try {
+            session = this.sessionFactory.openSession();
+
+            Transaction tx = session.beginTransaction();
+            session.update(roleAssignment);
+            tx.commit();
+        } finally {
+            if (session != null) session.close();
+        }
     }
 
     @Override
     public void delete(Long id) {
         RoleAssignment roleAssignment = find(id);
-        Session session = this.sessionFactory.openSession();
-        Transaction tx = session.beginTransaction();
-        session.delete(roleAssignment);
-        tx.commit();
-        session.close();
+        Session session = null;
+        try {
+            session = this.sessionFactory.openSession();
+
+            Transaction tx = session.beginTransaction();
+            session.delete(roleAssignment);
+            tx.commit();
+        } finally {
+            if (session != null) session.close();
+        }
     }
 }

--- a/datavault-common/src/main/java/org/datavaultplatform/common/model/dao/RoleAssignmentDaoImpl.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/model/dao/RoleAssignmentDaoImpl.java
@@ -1,9 +1,6 @@
 package org.datavaultplatform.common.model.dao;
 
-import org.datavaultplatform.common.model.Group;
-import org.datavaultplatform.common.model.RoleAssignment;
-import org.datavaultplatform.common.model.User;
-import org.datavaultplatform.common.model.Vault;
+import org.datavaultplatform.common.model.*;
 import org.hibernate.Criteria;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
@@ -104,6 +101,15 @@ public class RoleAssignmentDaoImpl implements RoleAssignmentDAO {
         List<RoleAssignment> schoolAssignments = findBy(session, "user", user);
         session.close();
         return schoolAssignments;
+    }
+
+    @Override
+    public List<RoleAssignment> findByRoleId(Long roleId) {
+        Session session = sessionFactory.openSession();
+        RoleModel role = findObjectById(session, RoleModel.class, "id", roleId);
+        List<RoleAssignment> assignments = findBy(session, "role", role);
+        session.close();
+        return assignments;
     }
 
     @Override

--- a/datavault-webapp/src/main/java/org/datavaultplatform/webapp/controllers/admin/AdminRolesController.java
+++ b/datavault-webapp/src/main/java/org/datavaultplatform/webapp/controllers/admin/AdminRolesController.java
@@ -41,32 +41,33 @@ public class AdminRolesController {
         mav.setViewName("admin/roles/index");
         mav.addObject("readOnlyRoles", restService.getViewableRoles());
         mav.addObject("roles", restService.getEditableRoles());
-        mav.addObject("isISAdmin", isIsAdmin(principal));
+        mav.addObject("isSuperAdmin", isSuperAdmin(principal));
+
         return mav;
     }
 
     @GetMapping("/admin/roles/isadmin")
-    public ModelAndView getIsAdminUsers(Principal principal) {
+    public ModelAndView getSuperAdminUsersListing(Principal principal) {
 
-        RoleModel role = restService.getIsAdmin();
-        List<User> isAdminUsers = restService.getRoleAssignmentsForRole(role.getId())
+        RoleModel superAdminRole = restService.getIsAdmin();
+        List<User> superAdminUsers = restService.getRoleAssignmentsForRole(superAdminRole.getId())
                 .stream()
-                .map(roleAssignment -> roleAssignment.getUser())
+                .map(RoleAssignment::getUser)
                 .collect(Collectors.toList());
 
         ModelAndView mav = new ModelAndView();
         mav.setViewName("admin/roles/isadmin/index");
-        mav.addObject("users", isAdminUsers);
-        mav.addObject("role", role);
+        mav.addObject("users", superAdminUsers);
+        mav.addObject("role", superAdminRole);
         return mav;
     }
 
     @PostMapping("/admin/roles/save")
     public ResponseEntity save(@RequestParam(value = "id") long id,
-                       @RequestParam(value = "name") String name,
-                       @RequestParam(value = "type") String type,
-                       @RequestParam(value = "description", required = false) String description,
-                       @RequestParam(value = "permissions", required = false) String[] permissions) {
+                               @RequestParam(value = "name") String name,
+                               @RequestParam(value = "type") String type,
+                               @RequestParam(value = "description", required = false) String description,
+                               @RequestParam(value = "permissions", required = false) String[] permissions) {
 
         Optional<RoleModel> stored = restService.getRole(id);
         if (!stored.isPresent()) {
@@ -79,9 +80,9 @@ public class AdminRolesController {
     }
 
     private ResponseEntity createNewRole(String name,
-                               String type,
-                               String description,
-                               String[] permissions) {
+                                         String type,
+                                         String description,
+                                         String[] permissions) {
 
         List<PermissionModel> selectedPermissions = getSelectedPermissions(type, permissions);
 
@@ -139,10 +140,10 @@ public class AdminRolesController {
     }
 
     private ResponseEntity updateRole(long id,
-                            String name,
-                            String type,
-                            String description,
-                            String[] permissions) {
+                                      String name,
+                                      String type,
+                                      String description,
+                                      String[] permissions) {
 
         RoleModel role = restService.getRole(id)
                 .orElseThrow(() -> new EntityNotFoundException(RoleModel.class, String.valueOf(id)));
@@ -200,27 +201,24 @@ public class AdminRolesController {
     }
 
     @PostMapping("/admin/roles/op")
-    public ResponseEntity addIsAdmin(Principal principal, @RequestParam("op-id") String userId) {
+    public ResponseEntity addSuperAdmin(@RequestParam("op-id") String userId) {
 
         logger.debug("Preparing to add user ID={} to IS ADMIN role", userId);
-        RoleModel role = restService.getIsAdmin();
+        RoleModel superAdminRole = restService.getIsAdmin();
         User user = restService.getUser(userId);
 
-        Optional<RoleAssignment> roleAssignment = restService.
+        if (restService.
                 getRoleAssignmentsForUser(userId)
                 .stream()
-                .filter(ra -> ra.getRole().equals(role))
-                .collect(MoreCollectors.toOptional());
-
-        if (roleAssignment.isPresent()) {
-            logger.warn("Cannot add the user ID={} to IS Admin Role ID={} because he already does have it.", userId, role.getId());
+                .anyMatch(ra -> ra.getRole().equals(superAdminRole))) {
+            logger.warn("Cannot add the user ID={} to IS Admin Role ID={} because he already does have it.", userId, superAdminRole.getId());
             return validationFailed("Can't add the user to this role, because he already is in it.");
         }
 
-        logger.info("Attempting to add user ID={} to IS Admin role with ID={}", userId, role.getId());
+        logger.info("Attempting to add user ID={} to IS Admin role with ID={}", userId, superAdminRole.getId());
 
         RoleAssignment newRoleAssignment = new RoleAssignment();
-        newRoleAssignment.setRole(role);
+        newRoleAssignment.setRole(superAdminRole);
         newRoleAssignment.setUser(user);
         restService.createRoleAssignment(newRoleAssignment);
 
@@ -228,28 +226,28 @@ public class AdminRolesController {
     }
 
     @PostMapping("/admin/roles/deop")
-    public ResponseEntity deleteIsAdmin(Principal principal, HttpServletRequest request, @RequestParam("deop-id") String userId) throws ServletException {
+    public ResponseEntity deleteSuperAdmin(Principal principal, HttpServletRequest request, @RequestParam("deop-id") String userId) throws ServletException {
 
         logger.debug("Preparing to remove user ID={} from IS ADMIN role", userId);
-        RoleModel role = restService.getIsAdmin();
+        RoleModel superAdminRole = restService.getIsAdmin();
 
-        if (restService.getRoleAssignmentsForRole(role.getId()).size() <= 1) {
-            logger.info("Rejected a request to remove the user ID={} from IS Admin role ID={} because there must be at least one IS Admin", userId, role.getId());
+        if (restService.getRoleAssignmentsForRole(superAdminRole.getId()).size() <= 1) {
+            logger.info("Rejected a request to remove the user ID={} from IS Admin role ID={} because there must be at least one IS Admin", userId, superAdminRole.getId());
             return validationFailed("Cannot remove the last IS Admin.");
         }
 
         Optional<RoleAssignment> roleAssignment = restService.
                 getRoleAssignmentsForUser(userId)
                 .stream()
-                .filter(ra -> ra.getRole().equals(role))
+                .filter(ra -> ra.getRole().equals(superAdminRole))
                 .collect(MoreCollectors.toOptional());
 
         if (!roleAssignment.isPresent()) {
-            logger.warn("Cannot remove the user ID={} from IS Admin Role ID={} because he doesn't have it.", userId, role.getId());
+            logger.warn("Cannot remove the user ID={} from IS Admin Role ID={} because he doesn't have it.", userId, superAdminRole.getId());
             return validationFailed("Can't remove the user from this role, because he already is not in it.");
         }
 
-        logger.info("Attempting to remove user ID={} from IS Admin role with ID={}", userId, role.getId());
+        logger.info("Attempting to remove user ID={} from IS Admin role with ID={}", userId, superAdminRole.getId());
         restService.deleteRoleAssignment(roleAssignment.get().getId());
 
         if (principal.getName().equals(userId)) {
@@ -290,18 +288,19 @@ public class AdminRolesController {
         return ResponseEntity.ok(permissions);
     }
 
-    private boolean isIsAdmin(Principal principal) {
+    private boolean isSuperAdmin(Principal principal) {
         if (principal == null) return false;
 
         // TODO: just pull from principal, when it starts having roles. For now: ask broker by name
-        // isAdminRole /should/ never be null.
-        RoleModel isAdminRole = restService.getIsAdmin();
+        // superAdminRole /should/ never be null.
+        RoleModel superAdminRole = restService.getIsAdmin();
 
         // Principal.getName() should give ID of the user, according to the existing code
         return restService
                 .getRoleAssignmentsForUser(principal.getName())
                 .stream()
-                .anyMatch(roleAssignment -> isAdminRole.equals(roleAssignment.getRole()));
+                .map(RoleAssignment::getRole)
+                .anyMatch(superAdminRole::equals);
 
     }
 }

--- a/datavault-webapp/src/main/java/org/datavaultplatform/webapp/controllers/admin/AdminRolesController.java
+++ b/datavault-webapp/src/main/java/org/datavaultplatform/webapp/controllers/admin/AdminRolesController.java
@@ -1,21 +1,26 @@
 package org.datavaultplatform.webapp.controllers.admin;
 
+import com.google.common.collect.MoreCollectors;
 import org.apache.commons.lang.StringUtils;
-import org.datavaultplatform.common.model.PermissionModel;
-import org.datavaultplatform.common.model.RoleModel;
-import org.datavaultplatform.common.model.RoleType;
+import org.datavaultplatform.common.model.*;
 import org.datavaultplatform.common.util.RoleUtils;
 import org.datavaultplatform.webapp.exception.EntityNotFoundException;
+import org.datavaultplatform.webapp.model.RoleViewModel;
 import org.datavaultplatform.webapp.services.RestService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.ModelAndView;
-import org.datavaultplatform.webapp.model.RoleViewModel;
 import org.testng.collections.Sets;
 
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import java.security.Principal;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -31,11 +36,28 @@ public class AdminRolesController {
     }
 
     @GetMapping("/admin/roles")
-    public ModelAndView getRolesListing() {
+    public ModelAndView getRolesListing(Principal principal) {
         ModelAndView mav = new ModelAndView();
         mav.setViewName("admin/roles/index");
         mav.addObject("readOnlyRoles", restService.getViewableRoles());
         mav.addObject("roles", restService.getEditableRoles());
+        mav.addObject("isISAdmin", isIsAdmin(principal));
+        return mav;
+    }
+
+    @GetMapping("/admin/roles/isadmin")
+    public ModelAndView getIsAdminUsers(Principal principal) {
+
+        RoleModel role = restService.getIsAdmin();
+        List<User> isAdminUsers = restService.getRoleAssignmentsForRole(role.getId())
+                .stream()
+                .map(roleAssignment -> roleAssignment.getUser())
+                .collect(Collectors.toList());
+
+        ModelAndView mav = new ModelAndView();
+        mav.setViewName("admin/roles/isadmin/index");
+        mav.addObject("users", isAdminUsers);
+        mav.addObject("role", role);
         return mav;
     }
 
@@ -177,6 +199,68 @@ public class AdminRolesController {
         return ResponseEntity.ok().build();
     }
 
+    @PostMapping("/admin/roles/op")
+    public ResponseEntity addIsAdmin(Principal principal, @RequestParam("op-id") String userId) {
+
+        logger.debug("Preparing to add user ID={} to IS ADMIN role", userId);
+        RoleModel role = restService.getIsAdmin();
+        User user = restService.getUser(userId);
+
+        Optional<RoleAssignment> roleAssignment = restService.
+                getRoleAssignmentsForUser(userId)
+                .stream()
+                .filter(ra -> ra.getRole().equals(role))
+                .collect(MoreCollectors.toOptional());
+
+        if (roleAssignment.isPresent()) {
+            logger.warn("Cannot add the user ID={} to IS Admin Role ID={} because he already does have it.", userId, role.getId());
+            return validationFailed("Can't add the user to this role, because he already is in it.");
+        }
+
+        logger.info("Attempting to add user ID={} to IS Admin role with ID={}", userId, role.getId());
+
+        RoleAssignment newRoleAssignment = new RoleAssignment();
+        newRoleAssignment.setRole(role);
+        newRoleAssignment.setUser(user);
+        restService.createRoleAssignment(newRoleAssignment);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/admin/roles/deop")
+    public ResponseEntity deleteIsAdmin(Principal principal, HttpServletRequest request, @RequestParam("deop-id") String userId) throws ServletException {
+
+        logger.debug("Preparing to remove user ID={} from IS ADMIN role", userId);
+        RoleModel role = restService.getIsAdmin();
+
+        if (restService.getRoleAssignmentsForRole(role.getId()).size() <= 1) {
+            logger.info("Rejected a request to remove the user ID={} from IS Admin role ID={} because there must be at least one IS Admin", userId, role.getId());
+            return validationFailed("Cannot remove the last IS Admin.");
+        }
+
+        Optional<RoleAssignment> roleAssignment = restService.
+                getRoleAssignmentsForUser(userId)
+                .stream()
+                .filter(ra -> ra.getRole().equals(role))
+                .collect(MoreCollectors.toOptional());
+
+        if (!roleAssignment.isPresent()) {
+            logger.warn("Cannot remove the user ID={} from IS Admin Role ID={} because he doesn't have it.", userId, role.getId());
+            return validationFailed("Can't remove the user from this role, because he already is not in it.");
+        }
+
+        logger.info("Attempting to remove user ID={} from IS Admin role with ID={}", userId, role.getId());
+        restService.deleteRoleAssignment(roleAssignment.get().getId());
+
+        if (principal.getName().equals(userId)) {
+            // Must logout IS Admin, if he just deopped himself
+            request.logout();
+            // He will be redirected to login by the JS when we return OK.
+        }
+
+        return ResponseEntity.ok().build();
+    }
+
     @GetMapping(value = "/admin/roles/{id}", produces = "application/json")
     public ResponseEntity<RoleViewModel> getRole(@PathVariable("id") long roleId) {
 
@@ -204,5 +288,20 @@ public class AdminRolesController {
     public ResponseEntity<List<PermissionModel>> getAllSchoolPermissions() {
         List<PermissionModel> permissions = restService.getSchoolPermissions();
         return ResponseEntity.ok(permissions);
+    }
+
+    private boolean isIsAdmin(Principal principal) {
+        if (principal == null) return false;
+
+        // TODO: just pull from principal, when it starts having roles. For now: ask broker by name
+        // isAdminRole /should/ never be null.
+        RoleModel isAdminRole = restService.getIsAdmin();
+
+        // Principal.getName() should give ID of the user, according to the existing code
+        return restService
+                .getRoleAssignmentsForUser(principal.getName())
+                .stream()
+                .anyMatch(roleAssignment -> isAdminRole.equals(roleAssignment.getRole()));
+
     }
 }

--- a/datavault-webapp/src/main/java/org/datavaultplatform/webapp/services/RestService.java
+++ b/datavault-webapp/src/main/java/org/datavaultplatform/webapp/services/RestService.java
@@ -17,7 +17,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.client.RestTemplate;
 
-import javax.management.relation.Role;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -617,6 +616,10 @@ public class RestService {
 
     public List<RoleAssignment> getRoleAssignmentsForUser(String userId) {
         return Arrays.asList(get(brokerURL + "/permissions/roleAssignments/user/" + userId, RoleAssignment[].class).getBody());
+    }
+
+    public List<RoleAssignment> getRoleAssignmentsForRole(Long roleId) {
+        return Arrays.asList(get(brokerURL + "/permissions/roleAssignments/role/" + roleId, RoleAssignment[].class).getBody());
     }
 
     public RoleModel updateRole(RoleModel role) {

--- a/datavault-webapp/src/main/java/org/datavaultplatform/webapp/services/RestService.java
+++ b/datavault-webapp/src/main/java/org/datavaultplatform/webapp/services/RestService.java
@@ -618,7 +618,7 @@ public class RestService {
         return Arrays.asList(get(brokerURL + "/permissions/roleAssignments/user/" + userId, RoleAssignment[].class).getBody());
     }
 
-    public List<RoleAssignment> getRoleAssignmentsForRole(Long roleId) {
+    public List<RoleAssignment> getRoleAssignmentsForRole(long roleId) {
         return Arrays.asList(get(brokerURL + "/permissions/roleAssignments/role/" + roleId, RoleAssignment[].class).getBody());
     }
 

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/admin/roles/index.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/admin/roles/index.ftl
@@ -15,6 +15,16 @@
             </div>
         </div>
 
+            <#if isISAdmin>
+                <div class="row">
+                    <div class="col-sm-4">
+                        <a class="layout_misc__subpage_link"
+                           href="${springMacroRequestContext.getContextPath()}/admin/roles/isadmin">Manage IS Admin
+                            role</a>
+                    </div>
+                </div>
+            </#if>
+
         <div class="layout_misc__add_new">
             <a id="addNewRoleBtn" href="#">+Add New Role</a>
         </div>

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/admin/roles/index.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/admin/roles/index.ftl
@@ -15,7 +15,7 @@
             </div>
         </div>
 
-            <#if isISAdmin>
+            <#if isSuperAdmin>
                 <div class="row">
                     <div class="col-sm-4">
                         <a class="layout_misc__subpage_link"

--- a/datavault-webapp/src/main/webapp/WEB-INF/freemarker/admin/roles/isadmin/index.ftl
+++ b/datavault-webapp/src/main/webapp/WEB-INF/freemarker/admin/roles/isadmin/index.ftl
@@ -1,0 +1,212 @@
+<#import "*/layout/defaultlayout.ftl" as layout>
+<#-- Specify which navbar element should be flagged as active -->
+<#global nav="admin">
+<@layout.vaultLayout>
+    <#import "/spring.ftl" as spring />
+
+    <div class="container container_layout">
+    <div>
+        <div class="row">
+            <div class="col-sm-4">
+                <h1 class="layout_roles_title">IS Admin Management</h1>
+            </div>
+            <div class="col-sm-8">
+                <!-- todo buttons (or not?) -->
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-sm-4">
+                <a class="layout_misc__subpage_link" href="${springMacroRequestContext.getContextPath()}/admin/roles">Back
+                    to role management</a>
+            </div>
+        </div>
+
+        <div class="layout_misc__add_new">
+            <a id="addNewAdminBtn" href="#" data-toggle="modal" data-target="#add-new-dialog">+Add New User</a>
+        </div>
+
+        <table class="table_layout">
+            <thead>
+            <tr class="tr">
+                <th class="table_layout__title">Name</th>
+                <th class="table_layout__actions">Actions</th>
+            </tr>
+            </thead>
+            <tbody>
+            <#list users as user>
+                <tr class="tr">
+                    <td>${user.getFirstname()} ${user.getLastname()}</td>
+                    <td>
+                        <#if users?size gt 1>
+                            <a href="#" class="btn btn-link modal_layout_action_btn" data-toggle="modal"
+                               data-target="#delete-dialog" data-role-name="${role.name}" data-user-id="${user.getID()}"
+                               data-user-name="${user.getFirstname()} ${user.getLastname()}" role="button"
+                               title="Remove user ${user.getFirstname()} ${user.getLastname()} from the ${role.name} role.">
+                                <i class="fa fa-trash-o"
+                                   style="font-size:24px;color:red;background:MistyRose;border:1px solid black;padding:2px"></i>
+                            </a>
+                        <#else>
+                            <a href="#" class="btn btn-link modal_layout_action_btn" disabled="disabled" role="button"
+                               title="This user is the last IS Admin and cannot be removed.">
+                                <i class="fa fa-trash-o"
+                                   style="font-size:24px;color:red;background:MistyRose;border:1px solid black;padding:2px"></i>
+                            </a>
+                        </#if>
+                    </td>
+                </tr>
+            </#list>
+            </tbody>
+        </table>
+
+        <div id="add-new-dialog" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="add-new-user-title"
+             aria-hidden="true">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <form id="create-form" class="form form-horizontal" role="form"
+                          action="${springMacroRequestContext.getContextPath()}/admin/role/op" method="post">
+                        <div class="modal-header">
+                            <button type="button" class="close" data-dismiss="modal" aria-hidden="true"><i
+                                        class="fa fa-times" aria-hidden="true"></i></button>
+                            <h4 class="modal-title" id="add-new-user-title">Add new user</h4>
+                        </div>
+                        <div class="modal-body">
+                            <div id="create-error" class="alert alert-danger hidden" role="alert"></div>
+                            <div class="form-group ui-widget">
+                                <label for="user-name" class="control-label col-sm-2">Name:</label>
+                                <div class="col-sm-10">
+                                    <input id="user-name" type="text" class="form-control" name="user" value=""/>
+                                </div>
+                            </div>
+                        </div>
+                        <#-- When Autocomplete comes around, hide this and set value from autocomplete events -->
+                        <div class="form-group ui-widget">
+                            <label for="op-user-id" class="control-label col-sm-2">For testing (will be hidden
+                                later):</label>
+                            <div class="col-sm-10">
+                                <input type="text" id="op-user-id" class="form-control" name="op-id" value=""/>
+                            </div>
+                        </div>
+                        <#-- --- -->
+                        <input type="hidden" id="submitAction" name="action" value="submit"/>
+                        <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                            <button type="submit" class="btn btn-primary btn-ok">Add</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+
+        <div id="delete-dialog" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="delete-title"
+             aria-hidden="true">
+            <div class="modal-dialog modal_layout_roles">
+                <div class="modal-content">
+                    <div class="modal-header modal_layout_roles_modal-header">
+                        <button type="button" class="close  modal_layout_roles_modal-header-close" data-dismiss="modal">
+                            <span class="glyphicon glyphicon-remove-circle  modal_layout_roles_modal-header-close"></span>
+                        </button>
+                        <h3 id="modal_title" class="layout_roles_title">Remove user from IS Admin role</h3>
+                    </div>
+                    <div class="modal-body modal_layout_roles_modal-body">
+                        <form id="delete-form" class="form form-horizontal" role="form"
+                              action="${springMacroRequestContext.getContextPath()}/admin/roles/deop" method="post">
+                            <div id="delete-error" class="alert alert-danger hidden"></div>
+                            <div class="modal-body">
+                                <p>Do you want to remove <label id="delete-user-name"></label> from the <label
+                                            id="delete-role-name"></label> role?</p>
+                            </div>
+                            <input type="hidden" id="delete-isadmin-user-id" name="deop-id"/>
+                            <input type="hidden" id="submitAction" name="action" value="submit"/>
+                            <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
+                            <div class="modal_layout_roles_modal-footer">
+                                <button type="button" class="btn btn-basic" data-dismiss="modal"><span
+                                            class="glyphicon glyphicon-remove-circle"></span> Cancel
+                                </button>
+                                <button type="submit" class="btn btn-primary"><i class="fa fa-trash"></i> Remove
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        $('[data-target="#delete-dialog"]').click(function () {
+            var roleName = $(this).data('role-name');
+            var userId = $(this).data('user-id');
+            var userName = $(this).data('user-name');
+            $('#delete-isadmin-user-id').val(userId);
+            $('#delete-role-name').text(roleName);
+            $('#delete-user-name').text(userName);
+            $('#delete-error').addClass('hidden').text('');
+        });
+
+        $('#delete-form').submit(function (event) {
+            event.preventDefault();
+            var formData = $(this).serialize();
+            $.ajax({
+                method: 'POST',
+                url: '${springMacroRequestContext.getContextPath()}/admin/roles/deop',
+                data: formData,
+                success: function () {
+                    window.location.href = '${springMacroRequestContext.getContextPath()}/admin/roles/isadmin';
+                },
+                error: function (xhr) {
+                    $('#delete-error').removeClass('hidden').text(xhr.responseText);
+                }
+            });
+        });
+
+        $('[data-target="#add-new-dialog"]').click(function () {
+            $('#create-error').addClass('hidden').text('');
+        });
+
+        $('#create-form').submit(function (event) {
+            event.preventDefault();
+            var formData = $(this).serialize();
+            $.ajax({
+                method: 'POST',
+                url: '${springMacroRequestContext.getContextPath()}/admin/roles/op/',
+                data: formData,
+                success: function () {
+                    window.location.href = '${springMacroRequestContext.getContextPath()}/admin/roles/isadmin';
+                },
+                error: function (xhr) {
+                    var $error = $('#create-error').removeClass('hidden').text(xhr.responseText);
+                }
+            });
+        });
+
+
+        $("#user-name").autocomplete({
+            autoFocus: true,
+            appendTo: "#add-new-dialog",
+            minLength: 2,
+            source: function (request, response) {
+                var term = request.term;
+                $.ajax({
+                    url: "${springMacroRequestContext.getContextPath()}/vaults/autocompleteuun/" + term,
+                    type: 'GET',
+                    dataType: "json",
+                    success: function (data) {
+                        response(data);
+                    }
+                });
+            },
+            select: function (event, ui) {
+                var attributes = ui.item.value.split(" - ");
+                this.value = attributes[0];
+                console.log("Autocomplete selected:");
+                console.log(event);
+                console.log(ui);
+                console.warn("When this actually works, then set the user id hidden field by selection data");
+                return false;
+            }
+        });
+    </script>
+
+</@layout.vaultLayout>

--- a/datavault-webapp/src/main/webapp/resources/theme/css/layout.css
+++ b/datavault-webapp/src/main/webapp/resources/theme/css/layout.css
@@ -61,6 +61,12 @@
     font-weight: bold;
 }
 
+.layout_misc__subpage_link {
+    margin: 40px 0;
+    font-size: 16px;
+    font-weight: bold;
+}
+
 .layout_roles_title {
     color: black;
     font-size: 36px;


### PR DESCRIPTION
Includes:
* Screen displaying current IS Admins
* Ability to add new users to the role
* Ability to remove users from the role
* Safeguard against removing last IS Admin

Notes:
* Race condition CAN occur where two delete IS Admin requests at the very same time might cause both to succeed. This is not transactional, and there is no locking.
* Autocomplete currently is not present, therefore there is an ability to specify the user id directly rather than by name search. It is mostly plumbed in though.