### PR TITLE
Ensure permissions deleted from the enum are also deleted from the db

### DIFF
--- a/datavault-common/src/main/java/org/datavaultplatform/common/model/dao/PermissionDAOImpl.java
+++ b/datavault-common/src/main/java/org/datavaultplatform/common/model/dao/PermissionDAOImpl.java
@@ -29,10 +29,16 @@ public class PermissionDAOImpl implements PermissionDAO {
         Session session = this.sessionFactory.openSession();
         Transaction tx = session.beginTransaction();
 
-        // First, remove any permissions that are not found in the Permission enum...
+        // First, remove any permissions that are no longer found in the Permission enum from all roles...
         String commaSeparatedPermissionIds = Arrays.stream(Permission.values())
                 .map(Permission::getId)
                 .collect(Collectors.joining(","));
+        String deleteUnknownRolePermissionsSql = "DELETE FROM Role_permissions WHERE NOT FIND_IN_SET(permission_id, '"
+                + commaSeparatedPermissionIds
+                + "');";
+        session.createSQLQuery(deleteUnknownRolePermissionsSql).executeUpdate();
+
+        // ...then remove those permissions themselves...
         String deleteUnknownPermissionsSql = "DELETE FROM Permissions WHERE NOT FIND_IN_SET(id, '"
                 + commaSeparatedPermissionIds
                 + "');";


### PR DESCRIPTION
Previously, when an entry was removed from the `Permission` enum which was applied to a role, the process to synchronise the enum with the database table was falling over due to a foreign key constraint violation. This change ensures that deleted permissions are removed from roles before being removed from the `Permissions` table, allowing us to temporarily use placeholder permissions without causing runtime errors when they're replaced with the actual permissions.